### PR TITLE
Add api, redis and kafka runners from protoype

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,2 @@
+*       @barryoneill @barambani @sirocchj
+

--- a/build.sbt
+++ b/build.sbt
@@ -40,6 +40,11 @@ val scalacOpts = Seq(
   "-Ywarn-numeric-widen" // Warn when numerics are widened.
 )
 
+lazy val customResolvers = Seq(
+  Resolver.bintrayRepo("ovotech", "maven"),
+  "Confluent" at "http://packages.confluent.io/maven/"
+)
+
 val V = new {
   val scalatest      = "3.0.7"
   val kindProjector  = "0.9.10"
@@ -50,18 +55,48 @@ val V = new {
   val logEffect      = "0.5.0"
   val refined        = "0.9.5"
   val logbackClassic = "1.2.3"
+  val ciris          = "0.12.1"
+  val fs2Kafka       = "0.19.9"
+  val circe          = "0.11.1"
+  val circeOptics    = "0.11.0"
+  val laserdisc      = "0.2.3"
+  val http4s         = "0.20.0-RC1"
+  val confluent      = "5.2.1"
+  val avro           = "1.8.2"
+  val prometheus     = "0.9.0-M5"
+  val diffson        = "3.1.1"
 }
 
 lazy val appDependencies = Seq(
-  "com.github.ghik" %% "silencer-lib"    % V.silencer,
-  "org.typelevel"   %% "cats-core"       % V.cats,
-  "org.typelevel"   %% "cats-effect"     % V.catsEffect,
-  "io.laserdisc"    %% "log-effect-core" % V.logEffect,
-  "io.laserdisc"    %% "log-effect-fs2"  % V.logEffect,
-  "co.fs2"          %% "fs2-core"        % V.fs2,
-  "eu.timepit"      %% "refined"         % V.refined,
-  "ch.qos.logback"  % "logback-classic"  % V.logbackClassic % Test,
-  "org.scalatest"   %% "scalatest"       % V.scalatest % Test
+  "com.github.ghik"         %% "silencer-lib"         % V.silencer,
+  "org.typelevel"           %% "cats-core"            % V.cats,
+  "org.typelevel"           %% "cats-effect"          % V.catsEffect,
+  "io.laserdisc"            %% "log-effect-core"      % V.logEffect,
+  "io.laserdisc"            %% "log-effect-fs2"       % V.logEffect,
+  "co.fs2"                  %% "fs2-core"             % V.fs2,
+  "eu.timepit"              %% "refined"              % V.refined,
+  "com.ovoenergy"           %% "fs2-kafka"            % V.fs2Kafka,
+  "org.apache.avro"         % "avro"                  % V.avro,
+  "io.confluent"            % "kafka-avro-serializer" % V.confluent,
+  "io.laserdisc"            %% "log-effect-core"      % V.logEffect,
+  "io.laserdisc"            %% "log-effect-fs2"       % V.logEffect,
+  "is.cir"                  %% "ciris-cats"           % V.ciris,
+  "is.cir"                  %% "ciris-core"           % V.ciris,
+  "is.cir"                  %% "ciris-refined"        % V.ciris,
+  "io.circe"                %% "circe-core"           % V.circe,
+  "io.circe"                %% "circe-generic"        % V.circe,
+  "io.circe"                %% "circe-parser"         % V.circe,
+  "io.circe"                %% "circe-optics"         % V.circeOptics,
+  "com.github.ghik"         %% "silencer-lib"         % V.silencer,
+  "io.laserdisc"            %% "laserdisc-core"       % V.laserdisc,
+  "io.laserdisc"            %% "laserdisc-fs2"        % V.laserdisc,
+  "org.http4s"              %% "http4s-dsl"           % V.http4s,
+  "org.http4s"              %% "http4s-circe"         % V.http4s,
+  "org.http4s"              %% "http4s-blaze-client"  % V.http4s,
+  "org.lyranthe.prometheus" %% "client"               % V.prometheus,
+  "org.gnieh"               %% "diffson-circe"        % V.diffson,
+  "ch.qos.logback"          % "logback-classic"       % V.logbackClassic % Test,
+  "org.scalatest"           %% "scalatest"            % V.scalatest % Test
 ) map (_.withSources)
 
 lazy val compilerPluginsDependencies = Seq(
@@ -78,6 +113,7 @@ lazy val root = project
     scalaVersion        := `scala 212`,
     scalacOptions       ++= scalacOpts,
     organization        := "io.laserdisc",
+    resolvers           ++= customResolvers,
     libraryDependencies ++= appDependencies ++ compilerPluginsDependencies,
     addCommandAlias("format", ";scalafmt;test:scalafmt;scalafmtSbt"),
     addCommandAlias(

--- a/src/main/scala/streamit/Settings.scala
+++ b/src/main/scala/streamit/Settings.scala
@@ -1,19 +1,75 @@
 package streamit
 
+import java.util.UUID
+
 import cats.Show
+import laserdisc.fs2.RedisAddress
+import laserdisc.{ Host, Port }
 
 sealed abstract class Settings {
-  // TODO: settings coming soon
+  val kafka: Option[KafkaSettings]
+  val api: Option[ApiSettings]
+  val redis: Option[RedisSettings]
 }
 
 object Settings {
 
-  @inline def apply(): Settings =
+  @inline def apply(
+    zks: Option[ZookeeperServer],
+    cgi: Option[ConsumerGroupId],
+    bts: Option[BootstrapServers],
+    sry: Option[SchemaRegistryURL],
+    abu: Option[APIBaseURL],
+    rho: Option[Host],
+    rpo: Option[Port],
+  ): Settings =
     new Settings {
-      // as we implement runner types, their settings will be grouped here
+      override val kafka: Option[KafkaSettings] = KafkaSettings.from(cgi, zks, bts, sry)
+      override val api: Option[ApiSettings]     = ApiSettings.from(abu)
+      override val redis: Option[RedisSettings] = RedisSettings.from(rho, rpo)
     }
 
   implicit val show: Show[Settings] = (s: Settings) => s"""
-                                                          TODO: settings coming soon
+                                                          | kafka: ${s.kafka}
+                                                          | api: ${s.api}
+                                                          | redis: ${s.redis}
       """.stripMargin
+}
+
+final case class ApiSettings(baseURL: APIBaseURL)
+
+final case class RedisSettings(redisAddress: RedisAddress)
+
+final case class KafkaSettings(
+  groupId: ConsumerGroupId,
+  zookeeper: Option[ZookeeperServer],
+  bootstrapServers: BootstrapServers,
+  schemaRegistry: SchemaRegistryURL
+)
+
+object ApiSettings {
+  def from(baseURL: Option[APIBaseURL]): Option[ApiSettings] =
+    baseURL.map(b => ApiSettings(b))
+}
+
+object KafkaSettings {
+  def from(
+    cgi: Option[ConsumerGroupId],
+    zks: Option[ZookeeperServer],
+    bts: Option[BootstrapServers],
+    sr: Option[SchemaRegistryURL]
+  ): Option[KafkaSettings] =
+    for {
+      c <- Some(cgi.getOrElse(s"stream-it-${UUID.randomUUID()}"))
+      b <- bts
+      s <- sr
+    } yield KafkaSettings(c, zks, b, s)
+}
+
+object RedisSettings {
+  def from(host: Option[Host], port: Option[Port]): Option[RedisSettings] =
+    for {
+      h <- host
+      p <- port
+    } yield RedisSettings(RedisAddress(h, p))
 }

--- a/src/main/scala/streamit/SpecRunner.scala
+++ b/src/main/scala/streamit/SpecRunner.scala
@@ -2,7 +2,6 @@ package streamit
 
 import cats.effect.{ ConcurrentEffect, ContextShift, Timer }
 import cats.instances.list._
-import cats.syntax.apply._
 import cats.syntax.flatMap._
 import cats.syntax.show._
 import cats.syntax.traverse._
@@ -19,9 +18,9 @@ import streamit.util.TestStats
   */
 case class Spec(tasks: Seq[Task]) {
   def logPreview[F[_]: ConcurrentEffect](implicit logger: LogWriter[F]): F[Unit] =
-    logger.info(s" =============== spec preview  =============== ") *>
-      logger.info(s" tasks to perform: ") *>
-      tasks.map(t => logger.info(s"  - ${t.getClass.getSimpleName}: ${t.desc}")).toList.sequence *>
+    logger.info(s" =============== spec preview  =============== ") >>
+      logger.info(s" tasks to perform: ") >>
+      tasks.map(t => logger.info(s"  - ${t.getClass.getSimpleName}: ${t.desc}")).toList.sequence >>
       logger.info(s" ============================================= ")
 }
 
@@ -35,14 +34,14 @@ final class SpecRunner[F[_]: ConcurrentEffect: ContextShift: Timer](settings: F[
       .flatMap { s =>
         def logSummary(stats: TestStats): Stream[F, TestStats] =
           Stream.eval {
-            logger.info(s" =============== results  =============== ") *>
-              stats.results.map(s => logger.info(s"  - ${s.show}")).sequence *>
+            logger.info(s" =============== results  =============== ") >>
+              stats.results.map(s => logger.info(s"  - ${s.show}")).sequence >>
               logger.info(
                 s"       ${stats.total} tests: ${stats.passed.size} passed, ${stats.failed.size} failed"
-              ) *>
+              ) >>
               logger.info(
                 s" =================== (duration: ${stats.durationMs}ms) ================== "
-              ) *>
+              ) >>
               ConcurrentEffect[F].pure(stats)
           }
 

--- a/src/main/scala/streamit/SpecRunner.scala
+++ b/src/main/scala/streamit/SpecRunner.scala
@@ -25,7 +25,7 @@ case class Spec(tasks: Seq[Task]) {
       logger.info(s" ============================================= ")
 }
 
-final class SpecRunner[F[_]: ConcurrentEffect: ContextShift: Timer](settings: Settings)(
+final class SpecRunner[F[_]: ConcurrentEffect: ContextShift: Timer](settings: F[Settings])(
   implicit logger: LogWriter[F]
 ) {
 

--- a/src/main/scala/streamit/Task.scala
+++ b/src/main/scala/streamit/Task.scala
@@ -1,6 +1,9 @@
 package streamit
 
-import scala.concurrent.duration.FiniteDuration
+import io.circe.Json
+
+import scala.concurrent.duration._
+import scala.util.matching.Regex
 
 /**
   * base trait for all tasks
@@ -10,13 +13,163 @@ sealed trait Task extends Product with Serializable {
 }
 
 /**
-  * trait for all tasks that aren't specific to something outside of this library
+  * Superclass of all kafka related tasks
+  */
+sealed trait KafkaTask extends Task
+
+/**
+  * Superclass of all redis related tasks
+  */
+sealed trait RedisTask extends Task
+
+/**
+  * Superclass of all rest related tasks
+  */
+sealed trait ApiTask extends Task
+
+/**
+  * Superclass of all Ger, non-system specific tasks
   */
 sealed trait GeneralTask extends Task
 
-/**
-  * Sleep for [[duration]]
-  */
 final case class Sleep(duration: FiniteDuration) extends GeneralTask {
   override def desc: String = s"Sleep for $duration"
 }
+
+/**
+  * Initialize the kafka consumer at the 'latest' offset for the given topic/group (this forces the
+  * consumer to the very latest offsets, regardless of whether existing offsets were present).
+  *
+  * @param topic The specified topic
+  */
+final case class KafkaConsumerToLatest(topic: Topic) extends KafkaTask {
+  override val desc: String = s"Move consumer to latest for $topic"
+}
+
+final case class KafkaSystemCheck() extends KafkaTask {
+  override def desc: String = s"Check that the configured kafka system is healthy"
+}
+
+/**
+  * Represents a key:value comparison to be performed against a kafka topic's configuration
+  * @param key The config key, which should exist
+  * @param expectedValue If `Some(v)`, then the config value for 'key' should match 'v'.  If `None`,
+  *                      but the config has a value for `key`, then this would indicate an error.
+  */
+final case class TopicConfigCheck(key: TopicConfigKey, expectedValue: Option[String]) {
+  override def toString: String = s"'$key'->${expectedValue.getOrElse("[UNSET]")}"
+}
+
+final case class KafkaTopicConfigCheck(
+  topic: Topic,
+  partitionCount: Int,
+  replicationFactor: Int,
+  configChecks: Seq[TopicConfigCheck]
+) extends KafkaTask {
+  override def desc: String =
+    s"Verify '$topic' has config: [" +
+      s"#partitions:$partitionCount" +
+      s", repl.factor:$replicationFactor" +
+      (if (configChecks.nonEmpty) { s", configChecks:$configChecks}}" }) +
+      s"]"
+}
+
+sealed trait KafkaTopicContentCheck extends KafkaTask {
+  def topic: Topic
+  def eventsSince: FiniteDuration
+  def timeout: FiniteDuration
+  override def desc: String =
+    s"Verify '$topic' has " +
+      s"events newer than $eventsSince (timeout:$timeout)"
+}
+
+final case class KafkaStringTopicContentCheck(
+  override val topic: Topic,
+  override val eventsSince: FiniteDuration,
+  override val timeout: FiniteDuration = 10.seconds,
+  keyRegex: Option[Regex] = None,
+  checkBodyIsJson: Boolean = false,
+) extends KafkaTopicContentCheck {
+  override def desc: String = {
+    val keyInfo = keyRegex.fold("") { r =>
+      s",a key matching '$r'"
+    }
+    val bodyInfo = if (checkBodyIsJson) ",a valid json value" else ""
+    s"${super.desc}$keyInfo$bodyInfo"
+  }
+}
+
+trait JsonPathCheck extends Product with Serializable {
+  val jsonPath: JsonPathExpr
+}
+final case class JsonPathEquals(override val jsonPath: JsonPathExpr, value: String)
+    extends JsonPathCheck
+final case class JsonPathMatches(override val jsonPath: JsonPathExpr, value: Regex)
+    extends JsonPathCheck
+
+final case class KafkaAvroTopicContentCheck(
+  override val topic: Topic,
+  override val eventsSince: FiniteDuration,
+  override val timeout: FiniteDuration,
+  keyChecks: Seq[JsonPathCheck],
+  valueChecks: Seq[JsonPathCheck],
+) extends KafkaTopicContentCheck {
+  override def desc: String = {
+    val kcInfo = if (keyChecks.nonEmpty) s",key checks=[${keyChecks.mkString(",")}]" else ""
+    val kvInfo = if (valueChecks.nonEmpty) s",value checks=[${valueChecks.mkString(",")}]" else ""
+    s"${super.desc}$kcInfo$kvInfo"
+  }
+}
+
+/**
+  * Publish an event to the specified kafka topic
+  *
+  * @param topic   The destination topic
+  * @param key     The event key
+  * @param payload The event payload
+  */
+final case class KafkaProduceString(
+  override val desc: String,
+  topic: Topic,
+  key: String,
+  payload: Json
+) extends KafkaTask
+
+/**
+  * Verify that the redis instance contains this value for the specified key
+  *
+  * @param key      The redis key
+  * @param expected The expected value
+  */
+final case class RedisGetAndVerify(override val desc: String, key: String, expected: Json)
+    extends RedisTask
+
+/**
+  * Verify that the event was published onto the specified topic.  This verification step will decode an
+  * avro-aware event, but then convert to JSON for verification
+  *
+  * @param topic    The topic to consume
+  * @param key The expected key JSON
+  * @param value The expected value JSON
+  * @param timeout How long to wait for the expected event before failing the task
+  */
+final case class KafkaAvroConsumeAndVerify(
+  override val desc: String,
+  topic: Topic,
+  key: Json,
+  value: Json,
+  timeout: FiniteDuration = 180.seconds
+) extends KafkaTask
+
+/**
+  * Verify that a GET call to the specified URI on the configured REST API will return the expected value
+  *
+  * @param uri      The URI on the configured REST API base URL to query
+  * @param expected The expected value
+  */
+final case class ApiGETAndVerify(
+  override val desc: String,
+  uri: String,
+  expected: Json,
+  headers: Map[String, String] = Map()
+) extends ApiTask

--- a/src/main/scala/streamit/client/ApacheKafkaClient.scala
+++ b/src/main/scala/streamit/client/ApacheKafkaClient.scala
@@ -51,7 +51,8 @@ class ApacheKafkaClient[F[_]: ConcurrentEffect](settings: KafkaSettings)(
     settings.zookeeper match {
       case None =>
         // zookeeper is an optional config, even if the kafkarunner gets configured
-        logger.infoS("Zookeeper host not configured, skipping ZK test")
+        logger
+          .infoS("Zookeeper host not configured, skipping ZK test")
           .flatMap(_ => Stream.empty)
       case Some(zkHost) =>
         Stream.bracketCase(
@@ -161,7 +162,7 @@ class ApacheKafkaClient[F[_]: ConcurrentEffect](settings: KafkaSettings)(
             )
 
           case Some(offsetAmt) =>
-            def toUTC(millis: Long) =
+            def toUTC(millis: Long): ZonedDateTime =
               ZonedDateTime.ofInstant(Instant.ofEpochMilli(millis), ZoneId.of("UTC"))
 
             resetOffsetListener(

--- a/src/main/scala/streamit/client/ApacheKafkaClient.scala
+++ b/src/main/scala/streamit/client/ApacheKafkaClient.scala
@@ -1,0 +1,257 @@
+package streamit.client
+
+import java.time.{ Instant, ZoneId, ZonedDateTime, Duration => JavaDuration }
+import java.util.{ Properties, Collection => JavaCollection }
+
+import cats.effect._
+import cats.syntax.apply._
+import fs2.Stream
+import fs2.kafka.{ KafkaConsumer => _ }
+import io.confluent.kafka.serializers.AbstractKafkaAvroSerDeConfig
+import log.effect.LogWriter
+import org.apache.kafka.clients.admin.{ AdminClient, AdminClientConfig }
+import org.apache.kafka.clients.consumer._
+import org.apache.kafka.common.TopicPartition
+import org.apache.kafka.common.serialization.Deserializer
+import org.apache.zookeeper.ZooKeeper
+import org.slf4j.LoggerFactory
+import streamit._
+
+import scala.collection.JavaConverters._
+import scala.concurrent.duration._
+
+object ApacheKafkaClient {
+  def apply[F[_]: ConcurrentEffect: LogWriter](kafkaSettings: KafkaSettings): ApacheKafkaClient[F] =
+    new ApacheKafkaClient(kafkaSettings)
+}
+
+/**
+  * While ideally an fs2-first client such as the fs2-kafka client would be the only one in use by the
+  * KafkaTaskRunner, it is quite limited (especially in documentation), so when we need to do lower level
+  * consumergroup manipulations, we need to resort to the standard java client, so that's all being
+  * isolated to this client.
+  */
+class ApacheKafkaClient[F[_]: ConcurrentEffect](settings: KafkaSettings)(
+  implicit logger: LogWriter[F]
+) {
+
+  // WARNING: Here be dragons.  Or at least, sphincter-tightening jumps between FP and non-FP with
+  // ugly java conversions. All help at making this less ugly, very, very welcome.
+
+  // kafka API listeners etc aren't in F[_] so we can't use 'logger' :(
+  private[this] val slfLogger = LoggerFactory.getLogger("ApacheKafkaClient")
+
+  /**
+    * @return A [[fs2.Stream]] containing a [[org.apache.zookeeper.ZooKeeper]] client, which will be
+    *         auto-closed via Stream.bracket.
+    */
+  def createZookeeperClient(): Stream[F, ZooKeeper] =
+    settings.zookeeper match {
+      case None =>
+        // zookeeper is an optional config, even if the kafkarunner gets configured
+        Stream
+          .eval(logger.warn("Zookeeper host not configured, skipping ZK test"))
+          .flatMap(_ => Stream.empty)
+      case Some(zkHost) =>
+        Stream.bracketCase(
+          ConcurrentEffect[F].delay(new ZooKeeper(zkHost, 10000, null)) <*
+            logger.info(s"Created zookeeper client to talk to zk host: $zkHost")
+        )(
+          (ac, _) =>
+            ConcurrentEffect[F].delay(ac.close()) *> logger.info(s"Zookeeper client Closed")
+        )
+    }
+
+  /**
+    * @return A [[fs2.Stream]] containing an [[org.apache.kafka.clients.admin.AdminClient]], which will be
+    *   auto-closed via Stream.bracket.
+    */
+  def createAdminClient(): Stream[F, AdminClient] = {
+    val properties = new Properties()
+    properties.put(AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG, settings.bootstrapServers)
+    Stream.bracketCase(
+      ConcurrentEffect[F].delay(AdminClient.create(properties)) <*
+        logger.info(
+          s"Created admin client to talk to bootstrap server: ${settings.bootstrapServers}"
+        )
+    )((ac, _) => ConcurrentEffect[F].delay(ac.close()) *> logger.info(s"Admin client closed"))
+  }
+
+  /**
+    * @return A [[fs2.Stream]] containing an [[org.apache.kafka.clients.consumer.KafkaConsumer]], which will be
+    *   auto-closed via Stream.bracket.
+    */
+  def createConsumer[K, V](
+    pollSize: Option[Int] = None,
+    bootstrapServers: Option[BootstrapServers] = None
+  )(implicit keyDes: Deserializer[K], valDes: Deserializer[V]): Stream[F, KafkaConsumer[K, V]] = {
+
+    val initialProps = new Properties()
+    initialProps.put(ConsumerConfig.REQUEST_TIMEOUT_MS_CONFIG, "30000")
+    initialProps.put(ConsumerConfig.CLIENT_ID_CONFIG, KafkaClientId)
+    initialProps.put(ConsumerConfig.GROUP_ID_CONFIG, settings.groupId.toString)
+    initialProps.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, keyDes.getClass)
+    initialProps.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, valDes.getClass)
+    pollSize.map(f => initialProps.put(ConsumerConfig.MAX_POLL_RECORDS_CONFIG, f.toString))
+    initialProps
+      .put(AbstractKafkaAvroSerDeConfig.SCHEMA_REGISTRY_URL_CONFIG, settings.schemaRegistry)
+
+    Stream(initialProps)
+      .map(props => {
+        props.put(
+          ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG,
+          bootstrapServers.getOrElse(settings.bootstrapServers)
+        )
+        props
+      })
+      .flatMap(props => {
+        Stream.bracketCase(
+          ConcurrentEffect[F].delay(new KafkaConsumer[K, V](props)) <*
+            logger.info(
+              s"Created consumer to bootstrap server: ${settings.bootstrapServers}, listing topics"
+            )
+        )((c, _) => ConcurrentEffect[F].delay(c.close()) *> logger.info("Consumer closed"))
+      })
+  }
+
+  /**
+    * @return A [[fs2.Stream]] containing an [[org.apache.kafka.clients.consumer.KafkaConsumer]], which will be
+    *   auto-closed via Stream.bracket.
+    */
+  def createConsumerForTopic[K, V](
+    topic: Topic,
+    offset: Option[Duration] = None,
+    pollSize: Option[Int] = None
+  )(implicit keyDes: Deserializer[K], valDes: Deserializer[V]): Stream[F, KafkaConsumer[K, V]] = {
+
+    def resetOffsetListener(
+      desc: String,
+      offsetChangeFunc: JavaCollection[TopicPartition] => Unit,
+    ): ConsumerRebalanceListener =
+      new ConsumerRebalanceListener {
+
+        override def onPartitionsAssigned(partitions: JavaCollection[TopicPartition]): Unit = {
+
+          val prettyFmt = partitions.asScala.groupBy(_.topic).map {
+            case (t, ids) =>
+              s"topic:$t, partitions: ${ids.map(_.partition()).toSeq.sorted.mkString(",")}"
+          }
+          slfLogger.info(s"Running rebalance listener '$desc' for: $prettyFmt")
+          offsetChangeFunc(partitions)
+        }
+
+        override def onPartitionsRevoked(partitions: JavaCollection[TopicPartition]): Unit = ()
+      }
+
+    createConsumer[K, V](pollSize)
+      .map(consumer => {
+
+        val offsetListener = offset match {
+
+          case None =>
+            resetOffsetListener(
+              "force to latest",
+              partitions => {
+                slfLogger.debug(
+                  s"Forcing partitions to latest for ${partitions.asScala.map(_.partition)}"
+                )
+                consumer.seekToEnd(partitions)
+              }
+            )
+
+          case Some(offsetAmt) =>
+            def toUTC(millis: Long) =
+              ZonedDateTime.ofInstant(Instant.ofEpochMilli(millis), ZoneId.of("UTC"))
+
+            resetOffsetListener(
+              s"rewinding to first event sent after $offsetAmt ago",
+              partitions => {
+
+                val now        = System.currentTimeMillis()
+                val offsetTime = now - offsetAmt.toMillis
+
+                // first, build the parition->desiredtiem query param
+                val offsetQuery = partitions.asScala.map(_ -> Long.box(offsetTime)).toMap.asJava
+
+                slfLogger.info(s"Requesting offsets for $offsetAmt ago (= ${toUTC(offsetTime)})")
+
+                // ask kafka for each paritition's offset at that point in time (might be null if no messages since!)
+                val pastOffsets = consumer.offsetsForTimes(offsetQuery).asScala
+
+                // seek each parition with an offset to that offset, the rest, scroll to latest.
+                pastOffsets.partition { case (_, o) => o != null } match {
+                  case (offsetsPresent, notPresent) =>
+                    offsetsPresent foreach {
+                      case (partition, desiredOffset: Any) =>
+                        slfLogger.info(
+                          s"'$partition' has events after $offsetAmt ago, seeking to offset " +
+                            s"${desiredOffset.offset()} for event at ${toUTC(desiredOffset.timestamp())}"
+                        )
+                        consumer.seek(partition, desiredOffset.offset())
+                    }
+
+                    if (notPresent.nonEmpty) {
+                      // in the case there's no offset for this timestamp, we force the consumer to the end
+                      // to ensure the poll() finds nothing in the case of an existing consumer group id
+                      slfLogger.debug(
+                        s"Seeking to end for following partitions as they contain no events since " +
+                          s"$offsetAmt ago (${toUTC(offsetTime)}: ${notPresent.keys}"
+                      )
+                      consumer.seekToEnd(notPresent.keys.asJavaCollection)
+                    }
+                }
+              }
+            )
+        }
+
+        consumer.subscribe(Seq(topic).asJava, offsetListener)
+
+        slfLogger.warn(
+          s"Returning a custom offset consumer which won't modify offsets until you poll()!"
+        )
+
+        consumer
+      })
+  }
+
+  def forceConsumerToLatest[K, V](
+    topic: Topic
+  )(implicit keyDes: Deserializer[K], valDes: Deserializer[V]): Stream[F, Unit] =
+    createConsumerForTopic[K, V](topic, pollSize = Some(1))
+      .evalTap(
+        _ => logger.info(s"Forcing consumer to latest for $topic")
+      )
+      .map(consumer => {
+        consumer.poll(JavaDuration.ofSeconds(5)).records(topic).asScala.toSeq
+        consumer.commitSync()
+        consumer.close()
+      })
+      .as(())
+
+  def pollWithOffset[K, V](
+    topic: Topic,
+    offset: Duration,
+    pollSize: Option[Int]
+  )(implicit keyDes: Deserializer[K], valDes: Deserializer[V]): Stream[F, ConsumerRecord[K, V]] =
+    createConsumerForTopic[K, V](topic, offset = Some(offset), pollSize = pollSize)
+      .evalTap(
+        _ =>
+          logger.info(
+            s"Polling $topic, offset=$offset, pollSize=${pollSize.fold("default") { _.toString }}"
+        )
+      )
+      .map(consumer => {
+        val recs = consumer.poll(JavaDuration.ofSeconds(5)).records(topic).asScala.toSeq
+        consumer.commitSync()
+        consumer.close()
+        recs
+      })
+      .evalTap(recs => {
+        val headOffset = recs.headOption.fold("n/a") { _.offset.toString }
+        val lastOffset = recs.lastOption.fold("n/a") { _.offset.toString }
+        logger.info(s"Finished poll, got ${recs.size}") *>
+          logger.debug(s"Offset of first record: $headOffset, last offset $lastOffset")
+      })
+      .flatMap(recs => Stream(recs: _*))
+
+}

--- a/src/main/scala/streamit/client/FS2KafkaClient.scala
+++ b/src/main/scala/streamit/client/FS2KafkaClient.scala
@@ -1,0 +1,66 @@
+package streamit.client
+
+import streamit._
+import cats.effect.{ ConcurrentEffect, _ }
+import fs2.Stream
+import fs2.kafka.{ Serializer => _, _ }
+import log.effect.LogWriter
+import log.effect.fs2.syntax._
+import org.apache.kafka.common.serialization.{ Deserializer, Serializer }
+import streamit.KafkaSettings
+
+object FS2KafkaClient {
+  def apply[F[_]: ConcurrentEffect: ContextShift: Timer: LogWriter](
+    settings: KafkaSettings
+  ): FS2KafkaClient[F] = new FS2KafkaClient(settings)
+}
+
+/**
+  * All fs2-kafka related activities
+  */
+class FS2KafkaClient[F[_]: ConcurrentEffect: ContextShift: Timer](settings: KafkaSettings)(
+  implicit logger: LogWriter[F]
+) {
+
+  def createConsumer[K, V](
+    topic: String
+  )(
+    implicit keyDes: Deserializer[K],
+    valDes: Deserializer[V]
+  ): Stream[F, CommittableMessage[F, K, V]] =
+    logger.infoS(
+      s"Creating consumer in ${settings.groupId} for topic $topic on server: ${settings.bootstrapServers}"
+    ) >>
+      (for {
+        ec <- consumerExecutionContextStream[F]
+        event <- consumerStream[F]
+                  .using(
+                    ConsumerSettings[K, V](keyDes, valDes, ec)
+                      .withAutoOffsetReset(AutoOffsetReset.Latest)
+                      .withClientId(KafkaClientId)
+                      .withBootstrapServers(settings.bootstrapServers)
+                      .withGroupId(settings.groupId.toString)
+                  )
+                  .evalTap(_.subscribeTo(topic))
+                  .flatMap(_.stream)
+                  .mapAsync(maxConcurrent = 25) { event =>
+                    ConcurrentEffect[F].pure(event)
+                  }
+
+      } yield event)
+
+  def createProducer[K, V](
+    implicit keySer: Serializer[K],
+    valSet: Serializer[V]
+  ): Stream[F, KafkaProducer[F, K, V]] =
+    logger.infoS(s"Creating producer to bootstrap server ${settings.bootstrapServers}") >>
+      producerStream[F]
+        .using(
+          ProducerSettings(keySer, valSet)
+            .withMaxInFlightRequestsPerConnection(1)
+            .withBootstrapServers(settings.bootstrapServers)
+            .withClientId(KafkaClientId)
+            .withAcks(Acks.All)
+        )
+
+}

--- a/src/main/scala/streamit/implicits/implicits.scala
+++ b/src/main/scala/streamit/implicits/implicits.scala
@@ -1,0 +1,87 @@
+package streamit
+
+import cats.effect.{ ConcurrentEffect, Timer }
+import cats.{ MonadError, Show }
+import fs2.{ Chunk, Pipe, Pull, Stream }
+import io.circe.parser.parse
+import io.circe.{ Json, JsonNumber, JsonObject }
+import streamit.util.CirceOpticsParser
+
+import scala.concurrent.duration.FiniteDuration
+import scala.language.implicitConversions
+
+package object implicits {
+
+  implicit class StringToJsonOps(val str: String) extends AnyVal {
+    def asJson: Json = parse(str) match {
+      case Left(parseFail) =>
+        // help circe be more helpful
+        throw parseFail copy (message = s"""Parse error '${parseFail.message}' for string: "$str"""")
+      case Right(expectedJson) => expectedJson
+    }
+
+    def asJsonF[F[_]](implicit F: MonadError[F, Throwable]): F[Json] = parse(str) match {
+      case Left(parseFail) =>
+        // help circe be more helpful
+        F.raiseError(
+          parseFail copy (message = s"""Parse error '${parseFail.message}' for string: "$str"""")
+        )
+      case Right(expectedJson) =>
+        F.pure(expectedJson)
+    }
+  }
+
+  implicit class JsonOps(val j: Json) {
+    private def canonicalJsonObject(j: JsonObject): JsonObject =
+      JsonObject.fromIterable(j.toVector.sortBy(_._1).map { case (k, j) => k -> canonicalJson_(j) })
+
+    private def canonicalJson_(j: Json): Json = j.fold[Json](
+      jsonNull = Json.Null,
+      jsonBoolean = (x: Boolean) => Json.fromBoolean(x),
+      jsonNumber = (x: JsonNumber) => Json.fromJsonNumber(x),
+      jsonString = (x: String) => Json.fromString(x),
+      jsonArray = (x: Vector[Json]) => Json.fromValues(x.sortBy(_.noSpaces).map(canonicalJson_)),
+      jsonObject = (x: JsonObject) => Json.fromJsonObject(canonicalJsonObject(x))
+    )
+
+    def canonicalJson: Json = canonicalJson_(j)
+  }
+
+  implicit class CirceOpticsDynamicOps(val json: Json) extends AnyVal {
+    def valueAtPath[V](path: JsonPathExpr)(implicit parser: CirceOpticsParser[V]): Option[V] =
+      parser.parse(json, path)
+  }
+
+  implicit class StreamOps[F[_], A](stream: Stream[F, A]) {
+
+    /**
+      * Runs the stream for at most `timeout` and short-circuits if `f()` is satisfied.
+      */
+    def runForAtMost(
+      f: A => Boolean,
+      timeout: FiniteDuration
+    )(implicit T: Timer[F], F: ConcurrentEffect[F]): Stream[F, A] = {
+      def p: Pipe[F, A, A] = {
+        def go(chunk: Chunk[A], s: Stream[F, A]): Pull[F, A, Unit] =
+          s.pull.uncons.flatMap {
+            case Some((hd, tl)) if hd.isEmpty =>
+              go(chunk, tl)
+            case Some((hd, tl)) =>
+              hd.find(f)
+                .fold {
+                  val ns = Chunk.concat(Seq(chunk, hd))
+                  go(ns, tl)
+                }(a => Pull.output1(a) >> Pull.done)
+            case None =>
+              if (chunk.isEmpty) Pull.done
+              else Pull.output(chunk) >> Pull.done
+          }
+
+        in =>
+          go(Chunk.empty, in).stream
+      }
+
+      stream.interruptWhen(Stream.emit(true).delayBy[F](timeout)).through(p)
+    }
+  }
+}

--- a/src/main/scala/streamit/implicits/syntax.scala
+++ b/src/main/scala/streamit/implicits/syntax.scala
@@ -1,7 +1,7 @@
 package streamit
 
+import cats.MonadError
 import cats.effect.{ ConcurrentEffect, Timer }
-import cats.{ MonadError, Show }
 import fs2.{ Chunk, Pipe, Pull, Stream }
 import io.circe.parser.parse
 import io.circe.{ Json, JsonNumber, JsonObject }
@@ -10,7 +10,7 @@ import streamit.util.CirceOpticsParser
 import scala.concurrent.duration.FiniteDuration
 import scala.language.implicitConversions
 
-package object implicits {
+package object syntax {
 
   implicit class StringToJsonOps(val str: String) extends AnyVal {
     def asJson: Json = parse(str) match {

--- a/src/main/scala/streamit/package.scala
+++ b/src/main/scala/streamit/package.scala
@@ -9,6 +9,19 @@ package object streamit {
   // remove this (letting the caller be restrictive), rather than the other way round..
   private[this] type AlphaNumDashes = String Refined MatchesRegex[W.`"^[a-zA-Z0-9\\\\-]+$"`.T]
 
-  final type AppName = AlphaNumDashes
+  // settings types
+  final type ZookeeperServer   = String
+  final type BootstrapServers  = String
+  final type SchemaRegistryURL = String
+  final type APIBaseURL        = String
+  final type Topic             = String
+
+  // kafka specific
+  val KafkaClientId = "stream-it"
+  final type ConsumerGroupId = String
+  final type TopicConfigKey  = String
+
+  // for verfications
+  final type JsonPathExpr = String
 
 }

--- a/src/main/scala/streamit/runner/ApiTaskRunner.scala
+++ b/src/main/scala/streamit/runner/ApiTaskRunner.scala
@@ -1,0 +1,90 @@
+package streamit.runner
+
+import cats.effect._
+import cats.syntax.apply._
+import fs2.Stream
+import io.circe.Json
+import log.effect.LogWriter
+import org.http4s.Status.{ NotFound, Successful }
+import org.http4s.circe._
+import org.http4s.client.blaze.BlazeClientBuilder
+import org.http4s.{ Header, Request, Uri }
+import streamit._
+import streamit.runner.Result.{ Failure, Success }
+
+import scala.concurrent.ExecutionContext.global
+
+object ApiTaskRunner {
+
+  def apply[F[_]: ConcurrentEffect: ContextShift: Timer: LogWriter](
+    settings: F[Settings]
+  ): Stream[F, ApiTaskRunner[F]] =
+    Stream
+      .eval(settings)
+      .map(_.api)
+      .flatMap {
+        case None    => Stream.apply(new NoOpApiTaskRunnerImpl())
+        case Some(s) => Stream.apply(new ApiTaskRunnerImpl(s))
+      }
+
+}
+
+sealed trait ApiTaskRunner[F[_]] extends TaskRunner[F, ApiTask]
+
+// TODO: extract common NoOp runner and eliminate this
+final class NoOpApiTaskRunnerImpl[F[_]] extends ApiTaskRunner[F] {
+  def run[TT >: ApiTask <: Task](task: TT): Stream[F, Result] = fail(task)
+}
+
+class ApiTaskRunnerImpl[F[_]](settings: ApiSettings)(
+  implicit F: ConcurrentEffect[F],
+  logger: LogWriter[F]
+) extends ApiTaskRunner[F] {
+
+  def run[TT >: ApiTask <: Task](task: TT): Stream[F, Result] =
+    task match {
+      case t: ApiGETAndVerify => runGetAndVerify(t)
+    }
+
+  def runGetAndVerify(t: ApiGETAndVerify): Stream[F, Result] = {
+
+    val path = s"${settings.baseURL}${t.uri}"
+
+    performGET(path, t.headers)
+      .collectFirst {
+        case jsonRec if jsonRec == t.expected => Success(t)
+        case jsonRec =>
+          Failure(t, s"Failed match GET on $path. Expected '${t.expected}', got '$jsonRec'")
+      }
+      .handleErrorWith(
+        e => Stream(Failure(t, s"${e.getClass.getName}: ${e.getMessage}"))
+      )
+  }
+
+  def performGET(path: String, headers: Map[String, String]): Stream[F, Json] =
+    Stream.eval(BlazeClientBuilder[F](global).resource.use(client => {
+
+      val request = Request[F](
+        uri = Uri.unsafeFromString(path)
+      ).withHeaders((headers map {
+        case (k, v) => Header(k, v).asInstanceOf[Header]
+      }).toList: _*)
+
+      logger.info(s"Performing GET on '$path'") *>
+        client.fetch[Json](request) {
+          case Successful(resp) => resp.decodeJson[Json]
+          case NotFound(_)      => F.raiseError(new Exception(s" response for $path"))
+          case resp =>
+            resp.bodyAsText
+              .flatMap(body => {
+                Stream.raiseError(
+                  new Exception(s"Unexected response for $path: $resp - body: $body")
+                )
+              })
+              .as(Json.Null)
+              .compile
+              .lastOrError
+        }
+
+    }))
+}

--- a/src/main/scala/streamit/runner/ApiTaskRunner.scala
+++ b/src/main/scala/streamit/runner/ApiTaskRunner.scala
@@ -1,7 +1,7 @@
 package streamit.runner
 
 import cats.effect._
-import cats.syntax.apply._
+import cats.syntax.flatMap._
 import fs2.Stream
 import io.circe.Json
 import log.effect.LogWriter
@@ -70,7 +70,7 @@ class ApiTaskRunnerImpl[F[_]](settings: ApiSettings)(
         case (k, v) => Header(k, v).asInstanceOf[Header]
       }).toList: _*)
 
-      logger.info(s"Performing GET on '$path'") *>
+      logger.info(s"Performing GET on '$path'") >>
         client.fetch[Json](request) {
           case Successful(resp) => resp.decodeJson[Json]
           case NotFound(_)      => F.raiseError(new Exception(s" response for $path"))

--- a/src/main/scala/streamit/runner/KafkaTaskRunner.scala
+++ b/src/main/scala/streamit/runner/KafkaTaskRunner.scala
@@ -1,0 +1,421 @@
+package streamit.runner
+
+import java.util.concurrent.TimeUnit
+
+import cats.effect._
+import cats.instances.list._
+import cats.syntax.apply._
+import cats.syntax.flatMap._
+import cats.syntax.traverse._
+import streamit.client.{ ApacheKafkaClient, FS2KafkaClient }
+import streamit.implicits._
+import streamit.util.AvroToJSONDeserializer
+import streamit._
+import fs2.Stream
+import fs2.kafka._
+import gnieh.diffson.circe._
+import io.circe.Json
+import log.effect.LogWriter
+import org.apache.kafka.clients.admin.TopicDescription
+import org.apache.kafka.clients.consumer.ConsumerRecord
+import org.apache.kafka.common.config.ConfigResource
+import org.apache.kafka.common.serialization.{
+  Deserializer,
+  Serializer,
+  StringDeserializer,
+  StringSerializer
+}
+import streamit.runner.Result.{ Failure, Success }
+
+import scala.collection.JavaConverters._
+import scala.util.matching.Regex
+
+object KafkaTaskRunner {
+
+  def apply[F[_]: ConcurrentEffect: ContextShift: Timer: LogWriter](
+    settings: F[Settings]
+  ): Stream[F, KafkaTaskRunner[F]] =
+    Stream
+      .eval(settings)
+      .map(_.kafka)
+      .flatMap {
+        case Some(ks) => Stream.apply(new KafkaTaskRunnerImpl(ks))
+        case None     => Stream.apply(new NoOpKafkaTaskRunnerImpl)
+      }
+}
+
+sealed trait KafkaTaskRunner[F[_]] extends TaskRunner[F, KafkaTask]
+
+// TODO: extract common NoOp runner and eliminate this
+final class NoOpKafkaTaskRunnerImpl[F[_]] extends KafkaTaskRunner[F] {
+  def run[TT >: KafkaTask <: Task](task: TT): Stream[F, Result] = fail(task)
+}
+
+class KafkaTaskRunnerImpl[F[_]: ConcurrentEffect: ContextShift: Timer](
+  kafkaSettings: KafkaSettings
+)(
+  implicit logger: LogWriter[F]
+) extends KafkaTaskRunner[F] {
+
+  /* While we prefer to use the fs2-kafka library exclusively, it has proven quite limited when it comes to
+   * lower level operations, such as offset manipulation, so we resort to the java client.  Both of these are
+   * isolated to their own classes. */
+  private[this] val fs2Client    = FS2KafkaClient[F](kafkaSettings)
+  private[this] val apacheClient = ApacheKafkaClient[F](kafkaSettings)
+
+  implicit val stringDes: Deserializer[String] = new StringDeserializer
+  implicit val stringSer: Serializer[String]   = new StringSerializer
+  implicit val avroDes: Deserializer[Json] = new AvroToJSONDeserializer(
+    kafkaSettings.schemaRegistry
+  )
+
+  def run[TT >: KafkaTask <: Task](task: TT): Stream[F, Result] =
+    task match {
+      case t: KafkaConsumerToLatest     => runConsumerToLatest(t)
+      case t: KafkaAvroConsumeAndVerify => runAvroConsumeAndVerify(t)
+      case t: KafkaTopicContentCheck    => runTopicContentCheck(t)
+      case t: KafkaProduceString        => runProduceString(t)
+      case t: KafkaSystemCheck          => runSystemCheck(t)
+      case t: KafkaTopicConfigCheck     => runTopicConfigCheck(t)
+    }
+
+  /**
+    * Subscribe the given consumer group ID to the specified topic, and seek to the latest offsets in the
+    * partitions assigned.  Normally, with 'auto.offset.reset'=latest, if offsets for this group already
+    * exist, those will be used.  This method overrides moving the consumer group offsets to the latest available
+    * in the partitions.
+    *
+    * This is useful for use cases where the test may not have run for some time, and in the meantime a
+    * large volume of data has been published to the target topic.  A test might  normally be disinterested
+    * in that data, so this lets us blow away any known offsets that would have forced us to consume them.
+    *
+    */
+  def runConsumerToLatest(task: KafkaConsumerToLatest): Stream[F, Result] =
+    apacheClient
+      .forceConsumerToLatest[String, String](task.topic)
+      .evalTap(
+        _ =>
+          logger.info(s"Consumer group ${kafkaSettings.groupId} offsets for ${task.topic} updated.")
+      )
+      .as(Success(task))
+
+  /** Consume from the specified topic until an event with the specified key is found, verifying that
+    * the provided payload matches, or fail if the timeout is reached.
+    */
+  def runAvroConsumeAndVerify(
+    task: KafkaAvroConsumeAndVerify
+  ): Stream[F, Result] =
+    task match {
+
+      case KafkaAvroConsumeAndVerify(_, topic, expectedKey, expectedValue, timeout) =>
+        fs2Client
+          .createConsumer[Json, Json](topic)
+          .evalTap(
+            event =>
+              event.record.key.hcursor.get[String]("orgId").getOrElse("n/a") match {
+                case "test" =>
+                  logger.info(
+                    s"Saw test event, key: ${event.record.key.noSpaces} while looking for ${expectedKey.noSpaces}"
+                  )
+                case otherOrg =>
+                  logger.debug(
+                    s"Saw $otherOrg event, key: ${event.record.key.noSpaces} while looking for ${expectedKey.noSpaces}"
+                  )
+            }
+          )
+          .filter(_.record.key == expectedKey)
+          .runForAtMost(m => m.record.value().canonicalJson == expectedValue.canonicalJson, timeout)
+          .evalTap(
+            evt =>
+              logger.debug(
+                s"Key '${expectedKey.noSpaces}' found, testing value: ${evt.record.value.noSpaces}"
+            )
+          )
+          .last
+          .map {
+            case Some(event) if event.record.value.canonicalJson == expectedValue.canonicalJson =>
+              Success(task)
+            case Some(event) =>
+              Failure(
+                task,
+                s"""Found expected key "${event.record.key.noSpaces} but value wasn't as expected:",
+                   | ------------------------------- Actual JSON ------------------------------- \n
+                   | ${event.record.value.canonicalJson.spaces2}\n
+                   | ------------------------------ Expected JSON ------------------------------ \n
+                   | ${expectedValue.canonicalJson.spaces2}\n
+                   | ------- To fix this, your 'expected' needs the following changes: --------- \n
+                   | ${JsonDiff.diff(
+                     expectedValue.canonicalJson,
+                     event.record.value.canonicalJson,
+                     remember = false
+                   )}\n
+                   | --------------------------------------------------------------------------- \n
+                   | """.stripMargin
+              )
+            case None => Failure(task, s"Gave up waiting ($timeout)")
+          }
+          .handleErrorWith(errToFailure(task))
+
+    }
+
+  /** Produce an event on the specified topic with the provided key and payload
+    */
+  def runProduceString(task: KafkaProduceString): Stream[F, Result] =
+    fs2Client
+      .createProducer[String, String]
+      .evalMap { producer =>
+        producer.produce(
+          ProducerMessage.one(ProducerRecord(task.topic, task.key, task.payload.noSpaces))
+        ) *>
+          logger.info(s"Produced event with key $task.key on topic $task.topic")
+      }
+      .as(Success(task))
+
+  /** Check that the specified topic contains data _after_ the specified offset.  In the successful
+    * case that data was present, perform some optional additional checks, such as key regex and
+    * value parsing.
+    */
+  def runTopicContentCheck[K, V](
+    task: KafkaTopicContentCheck
+  ): Stream[F, Result] =
+    task match {
+      case t: KafkaStringTopicContentCheck =>
+        runTopicContentCheck[String, String](
+          kafkaSettings.groupId,
+          t,
+          List(verifyBodyJson(t), verifyKeyRegex(t))
+        )
+      case t: KafkaAvroTopicContentCheck =>
+        runTopicContentCheck[Json, Json](kafkaSettings.groupId, t, List(verifyKey(t)))
+    }
+
+  def runTopicContentCheck[K, V](
+    groupId: ConsumerGroupId,
+    task: KafkaTopicContentCheck,
+    verifications: List[ConsumerRecord[K, V] => F[Unit]]
+  )(implicit keyDes: Deserializer[K], valDes: Deserializer[V]): Stream[F, Result] =
+    apacheClient
+      .pollWithOffset[K, V](
+        task.topic,
+        task.eventsSince,
+        Some(1)
+      )
+      .runForAtMost(_ => false, task.timeout)
+      .evalTap(
+        rec =>
+          logger.info(
+            s"Event found after ${task.eventsSince} ago on partition:${rec.partition}, " +
+              s"offset:${rec.offset()} with key ${rec.key}"
+        )
+      )
+      .evalTap(rec => {
+        logger.info(s"Performing ${verifications.size} verifications against record..") *>
+          verifications.map(v => v(rec)).sequence *>
+          logger.info(s"Verifications completed")
+      })
+      .last
+      .map {
+        case Some(_) => Success(task)
+        case None =>
+          Failure(task, s"Nothing in the last ${task.eventsSince}, timed out (${task.timeout})")
+      }
+      .handleErrorWith(errToFailure(task))
+
+  /**
+    * Verify that the specified topic exists and is configured as expected.
+    */
+  def runTopicConfigCheck(task: KafkaTopicConfigCheck): Stream[F, Result] = {
+
+    def validateConfigs(config: Map[String, String], checks: Seq[TopicConfigCheck]) =
+      checks.flatMap(
+        check =>
+          config.get(check.key) match {
+            case None =>
+              Some(s"Topic ${task.topic} missing configuration for key '${check.key}'")
+            case Some(actualValue) =>
+              check.expectedValue match {
+                case None =>
+                  Some(
+                    s"Topic ${task.topic} had unexpected config for key '${check.key}' (with value '$actualValue')"
+                  )
+                case Some(expVal) =>
+                  actualValue match {
+                    case v if v == expVal => None // validation passed!
+                    case _ =>
+                      Some(
+                        s"Topic ${task.topic} had expected config key '${check.key}', " +
+                          s"but unexpected value (expected:'$expVal', actual:'$actualValue')"
+                      )
+                  }
+              }
+        }
+      )
+
+    def validateParititionCount(td: TopicDescription, expectPartitions: Int): Option[String] =
+      Option(td.partitions().size() == expectPartitions).collect {
+        case false => s"Topic has ${td.partitions().size()} partitions, expected $expectPartitions"
+      }
+
+    def validateReplicationFactor(td: TopicDescription, expectReplFactor: Int): Option[String] =
+      td.partitions().asScala.headOption match {
+        case None => Some("Couldn't check replication factor, no partitions available!")
+        case Some(first) =>
+          Option(first.replicas().size() == expectReplFactor).collect {
+            case false =>
+              s"Topic has replication factor ${first.replicas().size()}, expected $expectReplFactor"
+          }
+      }
+
+    val adminClient = apacheClient.createAdminClient()
+
+    val topicState = adminClient
+      .map(_.describeTopics(Seq(task.topic).asJava))
+      .map(_.values().get(task.topic).get(5, TimeUnit.SECONDS)) // throws if topic unknown
+      .evalTap(
+        t =>
+          logger.info(s"Loaded info on ${t.partitions().size()} partitions for topic ${t.name()}")
+      )
+
+    val topicResource = new ConfigResource(ConfigResource.Type.TOPIC, task.topic)
+    val topicConfig = adminClient
+      .map(_.describeConfigs(Seq(topicResource).asJava))
+      .map(_.values().get(topicResource).get(1, TimeUnit.SECONDS)) // throws if topic unknown
+      .map(_.entries().asScala.map(e => e.name() -> e.value()).toMap)
+      .evalTap(
+        tConfig => logger.info(s"Loaded ${tConfig.keys.size} config keys for topic ${task.topic}")
+      )
+
+    topicState
+      .zip(topicConfig)
+      .flatMap {
+        case (state, config) =>
+          validateConfigs(config, task.configChecks) ++
+            Seq(
+              validateParititionCount(state, task.partitionCount),
+              validateReplicationFactor(state, task.replicationFactor)
+            ).flatten match {
+            case Nil      => Stream(Success(task))
+            case failures => Stream(Failure(task, s"Failed validations: $failures"))
+          }
+      }
+      .handleErrorWith(errToFailure(task))
+  }
+
+  /** Perform a system check against the configured system, by requesting a topic listing from
+    * each of the provided bootstrap servers individually, and if configured, the zookeeper host
+    * directly as well.
+    */
+  def runSystemCheck(task: KafkaSystemCheck): Stream[F, Result] = {
+
+    val zkCheck = apacheClient
+      .createZookeeperClient()
+      .map(_.getChildren("/brokers/topics", false))
+      .evalTap(topics => logger.info(s"Successfully queried ZK and saw ${topics.size()} topics"))
+      .evalTap(topics => logger.debug(s"ZK has topics: ${topics.asScala.toList}"))
+      .handleErrorWith(e => errStream(s"ZK check failed: ${e.getMessage}", e))
+
+    val brokerChecks = Stream
+      .emits(kafkaSettings.bootstrapServers.split(",").toList)
+      .evalTap(brokerList => logger.info(s"Will be checking $brokerList"))
+      .flatMap(bs => {
+        apacheClient
+          .createConsumer[String, String](bootstrapServers = Some(bs))
+          .map(_.listTopics(java.time.Duration.ofSeconds(5)))
+          .evalTap(
+            topics => logger.info(s"Bootstrap server $bs OK, has ${topics.keySet().size()} topics")
+          )
+          .handleErrorWith(e => errStream(s"Broker check to $bs failed: ${e.getMessage}", e))
+      })
+
+    Stream
+      .eval(zkCheck.compile.drain >> brokerChecks.compile.drain)
+      .as(Success(task))
+      .handleErrorWith(errToFailure(task))
+  }
+
+  private[this] def verifyKeyRegex(
+    task: KafkaStringTopicContentCheck
+  ): ConsumerRecord[String, String] => F[Unit] =
+    rec =>
+      task.keyRegex match {
+        case Some(keyRegex) => valueMatches(rec.key(), keyRegex, "while matching event key")
+        case _              => logger.info(s"No regex check, key was '${rec.key()}")
+    }
+
+  private[this] def verifyBodyJson(
+    task: KafkaStringTopicContentCheck
+  ): ConsumerRecord[String, String] => F[Unit] =
+    rec =>
+      if (task.checkBodyIsJson) {
+        rec
+          .value()
+          .asJsonF
+          .flatMap(
+            json => logger.info(s"Body for key '${rec.key()}' was valid JSON: ${json.spaces2}")
+          )
+      } else {
+        logger.info(
+          s"No JSON value check for event with key '${rec.key()}', value was: ${rec.value()}"
+        )
+    }
+
+  private[this] def verifyKey(
+    task: KafkaAvroTopicContentCheck
+  ): ConsumerRecord[Json, Json] => F[Unit] =
+    rec => {
+      verifyChecks("key", rec.key(), task.keyChecks) *>
+        verifyChecks("value", rec.value(), task.valueChecks)
+    }
+
+  private[this] def verifyChecks(desc: String, json: Json, checks: Seq[JsonPathCheck]): F[Unit] =
+    checks match {
+      case Nil => logger.info(s"No $desc checks to perform")
+      case cks =>
+        cks
+          .map { ck =>
+            val jsonPath = ck.jsonPath
+            val result: F[Unit] = json.valueAtPath[String](jsonPath) match {
+              case Some(v) =>
+                ck match {
+                  case c: JsonPathEquals =>
+                    valueEquals(
+                      v,
+                      c.value,
+                      s"while comparing jsonPath '$jsonPath' in $desc: '${json.noSpaces}'"
+                    )
+                  case c: JsonPathMatches =>
+                    valueMatches(
+                      v,
+                      c.value,
+                      s"while matching jsonPath '$jsonPath' in $desc: '${json.noSpaces}'"
+                    )
+                }
+              case None => errF(s"No value at JsonPath '$jsonPath' for JSON: ${json.noSpaces}")
+            }
+            result
+          }
+          .toList
+          .sequence *> logger.info(s"$desc checks completed")
+    }
+
+  private[this] def valueMatches(v: String, expected: Regex, context: String): F[Unit] = v match {
+    case expected() => logger.info(s"Value '$v' matches regex: $expected ($context)")
+    case _          => errF(s"Value '$v' does not match regex '$expected'  ($context)")
+  }
+
+  private[this] def valueEquals(value: String, expected: String, context: String): F[Unit] =
+    value match {
+      case v if v != expected =>
+        errF(s"Value '$v' did not match expected value '$expected' ($context)")
+      case _ => logger.info(s"Found expected value '$expected' ($context)")
+    }
+
+  private[this] def errF[T](msg: String): F[T] = ConcurrentEffect[F].raiseError(new Throwable(msg))
+  private[this] def errStream(msg: String, c: Throwable) =
+    Stream.raiseError[F](new Throwable(msg, c))
+  private[this] def errToFailure(task: Task): Throwable => Stream[F, Failure] =
+    e =>
+      Stream
+        .eval(logger.info(s"Error ${e.getClass.getName}: ${e.getMessage} caused $task to fail:", e))
+        .map(_ => Failure(task, s"${e.getClass.getName}: ${e.getMessage}"))
+}

--- a/src/main/scala/streamit/runner/KafkaTaskRunner.scala
+++ b/src/main/scala/streamit/runner/KafkaTaskRunner.scala
@@ -7,7 +7,7 @@ import cats.instances.list._
 import cats.syntax.flatMap._
 import cats.syntax.traverse._
 import streamit.client.{ ApacheKafkaClient, FS2KafkaClient }
-import streamit.implicits._
+import streamit.syntax._
 import streamit.util.AvroToJSONDeserializer
 import streamit._
 import fs2.Stream

--- a/src/main/scala/streamit/runner/RedisTaskRunner.scala
+++ b/src/main/scala/streamit/runner/RedisTaskRunner.scala
@@ -1,0 +1,82 @@
+package streamit.runner
+
+import java.nio.channels.AsynchronousChannelGroup.withThreadPool
+import java.util.concurrent.Executors.newFixedThreadPool
+
+import cats.MonadError
+import cats.effect._
+import cats.syntax.apply._
+import cats.syntax.flatMap._
+import fs2.Stream
+import laserdisc._
+import laserdisc.fs2.{ RedisClient => LaserDiscClient, _ }
+import log.effect.LogWriter
+import streamit._
+import streamit.implicits._
+import streamit.runner.Result.{ Failure, Success }
+
+object RedisTaskRunner {
+
+  def apply[F[_]: ConcurrentEffect: ContextShift: Timer: LogWriter](
+    settings: F[Settings]
+  ): Stream[F, RedisTaskRunner[F]] =
+    Stream
+      .eval(settings)
+      .map(_.redis)
+      .flatMap {
+        case None =>
+          Stream.apply(new RedisNoOpTaskRunner())
+
+        case Some(s) =>
+          val acgResource =
+            MkResource(ConcurrentEffect[F].delay(withThreadPool(newFixedThreadPool(2))))
+          Stream.resource(acgResource).flatMap { implicit acg =>
+            LaserDiscClient[F](Set(s.redisAddress)).map(new RedisTaskRunnerImpl(_))
+          }
+      }
+}
+
+sealed trait RedisTaskRunner[F[_]] extends TaskRunner[F, RedisTask]
+
+// TODO: extract common NoOp runner and eliminate this
+final class RedisNoOpTaskRunner[F[_]] extends RedisTaskRunner[F] {
+  def run[TT >: RedisTask <: Task](task: TT): Stream[F, Result] =
+    fail(task)
+}
+
+class RedisTaskRunnerImpl[F[_]](client: LaserDiscClient[F])(
+  implicit F: MonadError[F, Throwable],
+  logger: LogWriter[F]
+) extends RedisTaskRunner[F] {
+
+  def run[TT >: RedisTask <: Task](task: TT): Stream[F, Result] =
+    task match {
+      case t: RedisGetAndVerify => runGetAndVerify(t)
+    }
+
+  def runGetAndVerify(t: RedisGetAndVerify): Stream[F, Result] =
+    redisGetValue(Key.unsafeFrom(t.key))
+      .map(v => v.asJson)
+      .collectFirst {
+        case jsonRec if jsonRec == t.expected => Success(t)
+        case jsonRec =>
+          Failure(t, s"Failed match for key ${t.key}. Expected '${t.expected}', got '$jsonRec'")
+      }
+      .handleErrorWith(
+        e => Stream(Failure(t, s"${e.getClass.getName}: ${e.getMessage}"))
+      )
+
+  def redisGetValue(redisKey: Key): Stream[F, String] =
+    Stream.eval(client.send1(strings.get[String](redisKey)).flatMap {
+
+      case Right(Some(value)) =>
+        logger.info(s"For key $redisKey got value: $value") *> F.pure(value)
+
+      case Right(None) =>
+        F.raiseError[String](new RuntimeException(s"No value found for key: $redisKey"))
+
+      case Left(e) =>
+        F.raiseError[String](new RuntimeException(s"Error loading value for key: $redisKey", e))
+
+    })
+}

--- a/src/main/scala/streamit/runner/RedisTaskRunner.scala
+++ b/src/main/scala/streamit/runner/RedisTaskRunner.scala
@@ -5,7 +5,6 @@ import java.util.concurrent.Executors.newFixedThreadPool
 
 import cats.MonadError
 import cats.effect._
-import cats.syntax.apply._
 import cats.syntax.flatMap._
 import fs2.Stream
 import laserdisc._
@@ -70,7 +69,7 @@ class RedisTaskRunnerImpl[F[_]](client: LaserDiscClient[F])(
     Stream.eval(client.send1(strings.get[String](redisKey)).flatMap {
 
       case Right(Some(value)) =>
-        logger.info(s"For key $redisKey got value: $value") *> F.pure(value)
+        logger.info(s"For key $redisKey got value: $value") >> F.pure(value)
 
       case Right(None) =>
         F.raiseError[String](new RuntimeException(s"No value found for key: $redisKey"))

--- a/src/main/scala/streamit/runner/RedisTaskRunner.scala
+++ b/src/main/scala/streamit/runner/RedisTaskRunner.scala
@@ -11,7 +11,7 @@ import laserdisc._
 import laserdisc.fs2.{ RedisClient => LaserDiscClient, _ }
 import log.effect.LogWriter
 import streamit._
-import streamit.implicits._
+import streamit.syntax._
 import streamit.runner.Result.{ Failure, Success }
 
 object RedisTaskRunner {

--- a/src/main/scala/streamit/util/AvroToJSONDeserializer.scala
+++ b/src/main/scala/streamit/util/AvroToJSONDeserializer.scala
@@ -1,0 +1,96 @@
+package streamit.util
+
+import java.util.{ Map => JMap }
+
+import io.circe.Json
+import io.circe.parser._
+import io.confluent.kafka.schemaregistry.client.CachedSchemaRegistryClient
+import io.confluent.kafka.serializers.AbstractKafkaAvroSerDeConfig.SCHEMA_REGISTRY_URL_CONFIG
+import io.confluent.kafka.serializers.KafkaAvroDeserializer
+import org.apache.avro.generic.GenericRecord
+import org.apache.kafka.common.serialization.Deserializer
+import org.slf4j.LoggerFactory
+import streamit.SchemaRegistryURL
+
+import scala.collection.JavaConverters._
+
+/**
+  * A serializer which deserializes keys and values from an avro-aware topic, but marshals into circe [[Json]]
+  * objects, instead of requiring knowledge/access to avro model classes.  Allows the test to be as
+  * use-case agnostic as possible.
+  */
+class AvroToJSONDeserializer(schemaRegistry: Option[SchemaRegistryURL]) extends Deserializer[Json] {
+
+  // no logger in F[_] available here :(
+  private[this] val logger = LoggerFactory.getLogger(getClass)
+
+  /* Yes, avroDes is a var :(  This class is written to be compatible with both:
+   * - apache-kafka, which takes SerDe classnames via properties, and calls configure() to configure
+   * - fs2-kafka, which takes initialized instances of the deserializer (but doesn't call configure())
+   *
+   * This class supports both modes, but means that, in the case of the configure() route, the avro deserializer
+   * cannot be built until configure provides the schema registry url (The fs2 use case provides it in the constructor)
+   *
+   * TODO: find a 'safer' solution, but ensure that use cases for both clients still work afterwards :)
+   */
+  var avroDes: KafkaAvroDeserializer = _
+  schemaRegistry match {
+    case Some(url) => init(url)
+    case None =>
+      logger.debug(
+        "Constructed without registry url. Invoke configure() or init() before deserialization"
+      )
+  }
+
+  def this(schemaRegistry: SchemaRegistryURL) {
+    this(Some(schemaRegistry))
+  }
+
+  def this() {
+    this(None)
+  }
+
+  def init(schemaRegistryURL: SchemaRegistryURL): Unit = {
+    avroDes = new KafkaAvroDeserializer(new CachedSchemaRegistryClient(schemaRegistryURL, 1000))
+    logger.info(s"Initialized with schema registry: $schemaRegistryURL")
+  }
+
+  override def configure(configs: JMap[String, _], isKey: Boolean): Unit =
+    configs.asScala.get(SCHEMA_REGISTRY_URL_CONFIG).map(_.toString) match {
+      case Some(url) => init(url)
+      case _         =>
+        // would appear that configure() gets called several times :rolleyes: so don't throw
+        logger.warn(
+          s"Configure called, but $SCHEMA_REGISTRY_URL_CONFIG not present (saw: ${configs.asScala})"
+        )
+    }
+
+  override def deserialize(topic: String, data: Array[Byte]): Json =
+    try {
+
+      if (avroDes == null) {
+        throw new IllegalStateException(
+          "Cannot deserialize() until configure() " +
+            s"is called with a value for $SCHEMA_REGISTRY_URL_CONFIG"
+        )
+      }
+
+      val genericRecord = avroDes.deserialize(topic, data).asInstanceOf[GenericRecord]
+      parse(genericRecord.toString) match {
+        case Right(json) => json
+        case Left(failure) =>
+          logger.error(s"Failed to parse JSON from message: $failure - message was: $genericRecord")
+          Json.Null
+      }
+
+    } catch {
+      case e: Throwable =>
+        logger.error(s"Failure to deserialize message from topic $topic - $e", e)
+        Json.Null
+    }
+
+  override def close(): Unit = Option(avroDes) match {
+    case Some(a) => a.close()
+    case None    => logger.debug("close() invoked but no avrodes was created")
+  }
+}

--- a/src/main/scala/streamit/util/CirceOpticsParser.scala
+++ b/src/main/scala/streamit/util/CirceOpticsParser.scala
@@ -1,0 +1,39 @@
+package streamit.util
+
+import io.circe.optics.JsonPath
+import io.circe.optics.JsonPath._
+import io.circe.{ Json, JsonNumber, JsonObject }
+import streamit.JsonPathExpr
+
+trait CirceOpticsParser[V] {
+
+  /**
+    * Locate and return the element at the given JsonPath expression (as understood
+    * by https://circe.github.io/circe/optics.html) if found, converting to type V.
+    */
+  def parse(json: Json, path: JsonPathExpr): Option[V] = {
+    val jsonPath = root.selectDynamic(path)
+    selectOptional(jsonPath).getOption(json)
+  }
+
+  def selectOptional(jp: JsonPath): monocle.Optional[Json, V]
+}
+
+object CirceOpticsParser {
+
+  final type JsonPathExpr = String
+
+  // if you need a type that's not here, see what else io.circe.optics.JsonPath offers
+  implicit val boolParser: CirceOpticsParser[Boolean]          = (jp: JsonPath) => jp.boolean
+  implicit val byteParser: CirceOpticsParser[Byte]             = (jp: JsonPath) => jp.byte
+  implicit val shortParser: CirceOpticsParser[Short]           = (jp: JsonPath) => jp.short
+  implicit val intParser: CirceOpticsParser[Int]               = (jp: JsonPath) => jp.int
+  implicit val longParser: CirceOpticsParser[Long]             = (jp: JsonPath) => jp.long
+  implicit val bigintParser: CirceOpticsParser[BigInt]         = (jp: JsonPath) => jp.bigInt
+  implicit val doubleParser: CirceOpticsParser[Double]         = (jp: JsonPath) => jp.double
+  implicit val bigdecimalParser: CirceOpticsParser[BigDecimal] = (jp: JsonPath) => jp.bigDecimal
+  implicit val jsNumberParser: CirceOpticsParser[JsonNumber]   = (jp: JsonPath) => jp.number
+  implicit val stringParser: CirceOpticsParser[String]         = (jp: JsonPath) => jp.string
+  implicit val jsArrayParser: CirceOpticsParser[Vector[Json]]  = (jp: JsonPath) => jp.arr
+  implicit val jsObjecParser: CirceOpticsParser[JsonObject]    = (jp: JsonPath) => jp.obj
+}

--- a/src/test/resources/logback.xml
+++ b/src/test/resources/logback.xml
@@ -11,4 +11,24 @@
     </root>
 
 
+    <!-- turning these off makes 'DEBUG' usable for everything else -->
+    <logger name="fs2.kafka" additivity="false" level="WARN"/>
+    <logger name="org.apache.kafka.common" additivity="false" level="WARN"/>
+    <logger name="org.apache.kafka.clients" additivity="false" level="WARN"/>
+    <logger name="org.apache.kafka.clients.producer" additivity="false" level="WARN"/>
+    <logger name="org.apache.kafka.clients.consumer" additivity="false" level="WARN"/>
+    <logger name="io.confluent.kafka.schemaregistry" additivity="false" level="WARN"/>
+
+    <!-- set to INFO when troubleshooting consumergroup/partion offset info, but too noisy for normal use -->
+    <logger name="org.apache.kafka.clients.consumer.internals.Fetcher" additivity="false" level="WARN"/>
+    <logger name="org.apache.kafka.clients.consumer.internals.AbstractCoordinator" additivity="false" level="WARN"/>
+    <logger name="org.apache.kafka.clients.consumer.internals.ConsumerCoordinator" additivity="false" level="WARN"/>
+
+    <!-- not really useful, even at info -->
+    <logger name="org.apache.zookeeper.ZooKeeper" additivity="false" level="WARN"/>
+    <logger name="org.apache.kafka.clients.Metadata" additivity="false" level="WARN"/>
+    <logger name="org.apache.kafka.common.utils.AppInfoParser" additivity="false" level="WARN"/>
+    <logger name="org.apache.kafka.clients.admin.AdminClientConfig" additivity="false" level="WARN"/>
+
+
 </configuration>

--- a/src/test/scala/streamit/StreamItSpec.scala
+++ b/src/test/scala/streamit/StreamItSpec.scala
@@ -21,15 +21,20 @@ trait StreamItSpec extends WordSpec {
 
   implicit protected lazy val timer: Timer[IO] = IO.timer(ec)
 
-  def runSpecWithIO(spec: Spec): TestStats =
+  def runSpecWithIO(spec: Spec): TestStats = {
+
+    // TODO: we'll flesh optionals out as we add coverage for runners
+    val settings = IO.pure(Settings(None, None, None, None, None, None, None))
+
     log4sLog[IO]("stream-it")
       .flatMap { implicit logger =>
         logger.info("starting app") *>
-          new SpecRunner[IO](Settings())
+          new SpecRunner[IO](settings)
             .run(spec)
             .compile
             .toList
       }
       .unsafeRunSync()
       .head
+  }
 }

--- a/src/test/scala/streamit/StreamItSpec.scala
+++ b/src/test/scala/streamit/StreamItSpec.scala
@@ -28,7 +28,7 @@ trait StreamItSpec extends WordSpec {
 
     log4sLog[IO]("stream-it")
       .flatMap { implicit logger =>
-        logger.info("starting app") *>
+        logger.info("starting app") >>
           new SpecRunner[IO](settings)
             .run(spec)
             .compile


### PR DESCRIPTION
This brings in the runners from the prototype, but modified for the spec-less approach. I think the next work will be to add proper test coverage of them, but it'll be difficult without some sort of kafka / redis support..

[Also, sorry about the size]